### PR TITLE
Restore cryptography

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Setup:
 
 ````
 python3 -m venv venv
+venv/bin/python -m pip install --upgrade pip
 venv/bin/python -m pip install -r requirements.txt
 ````
 

--- a/cipher.py
+++ b/cipher.py
@@ -3,15 +3,15 @@ import os, binascii
 from passlib.hash import pbkdf2_sha256
 import varint
 import hashlib
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 def encrypt(data: str):
     salt = binascii.unhexlify('646464646464646464646464')
     salt_encoded = base64.b64decode(salt)
     key = hashlib.pbkdf2_hmac('sha256', b'test', salt_encoded, 10000, 32)
     nonce = binascii.unhexlify('656565656565656565656565')
-    cipher = AES.new(key, AES.MODE_GCM, nonce=nonce)
-    encrypted = cipher.encrypt(data.encode("utf-8"))
+    cipher = AESGCM(key)
+    encrypted = cipher.encrypt(nonce, data.encode("utf-8"), None)
     result = bytearray()
     result.extend(varint.encode(0))
     result.extend(salt)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ numpy
 passlib
 varint
 pandas
-pycryptodome
+cryptography
 ed25519
 passlib
 blake3

--- a/wrapper/config.py
+++ b/wrapper/config.py
@@ -56,7 +56,13 @@ if __name__ == "__main__":
     initial_ledger = {}
     for node in nodes:
         if node["initial_ledger_sequential_balance"] > 0:
-            initial_ledger[node["address"]] = { "sequential_balance": str(node["initial_ledger_sequential_balance"]), "parallel_balance": str(node["initial_ledger_parallel_balance"]),  "datastore": {}, "bytecode": [] }
+            initial_ledger[node["address"]] = {
+                "sequential_balance": str(node["initial_ledger_sequential_balance"]),
+                "parallel_balance": str(node["initial_ledger_parallel_balance"]),
+                "balance": str(node["initial_ledger_parallel_balance"]),
+                "datastore": {},
+                "bytecode": []
+            }
 
     print(initial_ledger)
     with open(NODE_INITIAL_LEDGER_PATH, "w") as initial_ledger_json_file:


### PR DESCRIPTION
Using pycryptodome, break the network simulator on Ubuntu 22.04.1 + python 3.10.6 so I reverted the changes.

Goal is to test it with as much config as possible and see if it can fit everyone. Please try from a fresh clone and create a new virtual env with: 

python3 -m venv venv && venv/bin/python -m pip install --upgrade pip && venv/bin/python -m pip install -r requirements.txt

then try to launch the simulator and report :)

